### PR TITLE
Added quiz functionality

### DIFF
--- a/src/modules/course/model/course.model.js
+++ b/src/modules/course/model/course.model.js
@@ -2,17 +2,19 @@ import mongoose, { Schema } from 'mongoose';
 import { CourseLevelEnum } from '../../../enums/course-level.enum.js';
 import { CourseStatusEnums } from '../../../enums/course-status.enum.js';
 import { CourseSubscriptionEnum } from '../../../enums/course-subscription.enum.js';
+import { ChapterTypeEnum } from '../../../enums/chapter-type.enum.js';
 
 // Chapter Schema
 const chapterSchema = new Schema({
   chapterId: { type: String, required: true },
   type: {
     type: String,
-    enum: ['Text', 'Video'],
+    enum: Object.values(ChapterTypeEnum),
+    required: true,
   },
   title: { type: String },
   content: { type: String },
-  video: { type: String },
+  video: { type: String }, 
   duration: { type: Number }, // duration in minutes for videos
 });
 

--- a/src/modules/quiz/controllers/quiz.controller.js
+++ b/src/modules/quiz/controllers/quiz.controller.js
@@ -1,0 +1,246 @@
+import { HTTPSTATUS } from '../../../configs/http.config.js';
+import AsyncHandler from '../../../middlewares/asyncHandler.js';
+import QuizModel from '../model/quiz.model.js';
+import CourseModel from '../../course/model/course.model.js';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Get all quizzes for a course
+ */
+export const getQuizzesByCourse = AsyncHandler(async (req, res) => {
+  const { courseId } = req.params;
+  
+  const quizzes = await QuizModel.find({ courseId })
+    .select('quizId sectionId chapterId title description timeLimit passingScore isActive createdAt')
+    .lean();
+  
+  // Since we're using lean(), we need to process the questions array safely if it exists
+  const processedQuizzes = Array.isArray(quizzes) ? quizzes.map(quiz => 
+    quiz.questions ? QuizModel.omitAnswersFromLeanDocument(quiz) : quiz
+  ) : [];
+  
+  res.status(HTTPSTATUS.OK).json({
+    success: true,
+    count: processedQuizzes.length,
+    data: processedQuizzes,
+  });
+});
+
+/**
+ * Get all quizzes for a section
+ */
+export const getQuizzesBySection = AsyncHandler(async (req, res) => {
+  const { sectionId } = req.params;
+  
+  const quizzes = await QuizModel.find({ sectionId })
+    .select('quizId title description timeLimit passingScore isActive createdAt')
+    .lean();
+  
+  // Since we're using lean(), we need to process the questions array safely if it exists
+  const processedQuizzes = Array.isArray(quizzes) ? quizzes.map(quiz => 
+    quiz.questions ? QuizModel.omitAnswersFromLeanDocument(quiz) : quiz
+  ) : [];
+  
+  res.status(HTTPSTATUS.OK).json({
+    success: true,
+    count: processedQuizzes.length,
+    data: processedQuizzes,
+  });
+});
+
+/**
+ * Get a single quiz without answers
+ */
+export const getQuizById = AsyncHandler(async (req, res) => {
+  const { quizId } = req.params;
+  
+  const quiz = await QuizModel.findOne({ quizId });
+  
+  if (!quiz) {
+    res.status(HTTPSTATUS.NOT_FOUND).json({
+      success: false,
+      message: 'Quiz not found',
+    });
+    return;
+  }
+  
+  // Use the custom method to omit answers
+  const quizWithoutAnswers = quiz.omitAnswers();
+  
+  res.status(HTTPSTATUS.OK).json({
+    success: true,
+    data: quizWithoutAnswers,
+  });
+});
+
+/**
+ * Create a new quiz and associate it with a section
+ */
+export const createQuiz = AsyncHandler(async (req, res) => {
+  const { courseId, sectionId, title, description, timeLimit, passingScore, questions } = req.body;
+
+  // 1. Verify the course and section exist
+  const course = await CourseModel.findById(courseId);
+  if (!course) {
+    return res.status(HTTPSTATUS.NOT_FOUND).json({ success: false, message: 'Course not found' });
+  }
+
+  const section = course.sections.find(s => s.sectionId === sectionId);
+  if (!section) {
+    return res.status(HTTPSTATUS.NOT_FOUND).json({ success: false, message: 'Section not found in this course' });
+  }
+  
+  // 2. Check if a quiz already exists for this section
+  if (section.quizId) {
+      return res.status(HTTPSTATUS.BAD_REQUEST).json({ success: false, message: 'A quiz already exists for this section' });
+  }
+
+  // 3. Generate a unique quizId
+  const quizId = uuidv4();
+
+  // 4. Format questions with unique IDs
+  const formattedQuestions = questions.map(q => ({
+    questionId: uuidv4(),
+    text: q.text,
+    explanation: q.explanation,
+    options: q.options.map(opt => ({
+      id: uuidv4(),
+      text: opt.text,
+      isCorrect: opt.isCorrect,
+    })),
+  }));
+
+  // 5. Create the new quiz
+  const quiz = await QuizModel.create({
+    quizId,
+    courseId,
+    sectionId, // A quiz is associated with a section
+    title,
+    description,
+    timeLimit,
+    passingScore,
+    questions: formattedQuestions,
+    isActive: true,
+    createdBy: req.user.id,
+  });
+
+  // 6. Update the course's section with the new quizId
+  section.quizId = quizId;
+  await course.save();
+
+  // 7. Return the created quiz (without answers)
+  const safeQuiz = quiz.omitAnswers();
+
+  res.status(HTTPSTATUS.CREATED).json({
+    success: true,
+    message: 'Quiz created and associated with section successfully',
+    data: safeQuiz,
+  });
+});
+
+/**
+ * Update a quiz
+ */
+export const updateQuiz = AsyncHandler(async (req, res) => {
+  const { quizId } = req.params;
+  const { title, description, timeLimit, passingScore, questions, isActive } = req.body;
+  
+  // Find the quiz by quizId (not MongoDB _id)
+  const quiz = await QuizModel.findOne({ quizId });
+  
+  if (!quiz) {
+    res.status(HTTPSTATUS.NOT_FOUND).json({
+      success: false,
+      message: 'Quiz not found',
+    });
+    return;
+  }
+  
+  // Only allow the creator to update the quiz
+  if (quiz.createdBy.toString() !== req.user.id.toString()) {
+    res.status(HTTPSTATUS.FORBIDDEN).json({
+      success: false,
+      message: 'You are not authorized to update this quiz',
+    });
+    return;
+  }
+  
+  // Update fields if provided
+  if (title) quiz.title = title;
+  if (description) quiz.description = description;
+  if (timeLimit) quiz.timeLimit = timeLimit;
+  if (passingScore) quiz.passingScore = passingScore;
+  if (typeof isActive === 'boolean') quiz.isActive = isActive;
+  
+  // Update questions if provided
+  if (questions && Array.isArray(questions) && questions.length > 0) {
+    const formattedQuestions = questions.map(question => ({
+      questionId: question.questionId || uuidv4(),
+      text: question.text,
+      explanation: question.explanation,
+      options: question.options.map(option => ({
+        id: option.id || uuidv4(),
+        text: option.text,
+        isCorrect: option.isCorrect,
+      })),
+    }));
+    
+    quiz.questions = formattedQuestions;
+  }
+  
+  await quiz.save();
+  
+  // Return updated quiz without answers
+  const safeQuiz = quiz.omitAnswers();
+  
+  res.status(HTTPSTATUS.OK).json({
+    success: true,
+    message: 'Quiz updated successfully',
+    data: safeQuiz,
+  });
+});
+
+/**
+ * Delete a quiz
+ */
+export const deleteQuiz = AsyncHandler(async (req, res) => {
+  const { quizId } = req.params;
+  
+  const quiz = await QuizModel.findOne({ quizId });
+  
+  if (!quiz) {
+    return res.status(HTTPSTATUS.NOT_FOUND).json({
+      success: false,
+      message: 'Quiz not found',
+    });
+  }
+  
+  // Only allow the creator to delete the quiz
+  if (quiz.createdBy.toString() !== req.user.id.toString()) {
+    return res.status(HTTPSTATUS.FORBIDDEN).json({
+      success: false,
+      message: 'You are not authorized to delete this quiz',
+    });
+  }
+  
+  // Get quiz details before deletion for course update
+  const { courseId, sectionId } = quiz;
+  
+  // Remove the quiz document
+  await QuizModel.deleteOne({ quizId });
+  
+  // Remove the quiz reference from the course's section
+  const courseToUpdate = await CourseModel.findById(courseId);
+  if (courseToUpdate) {
+    const section = courseToUpdate.sections.find(s => s.sectionId === sectionId);
+    if (section && section.quizId === quizId) {
+      section.quizId = null; // Remove the quiz reference
+      await courseToUpdate.save();
+    }
+  }
+  
+  res.status(HTTPSTATUS.OK).json({
+    success: true,
+    message: 'Quiz deleted and removed from section successfully',
+  });
+});

--- a/src/modules/quiz/model/quiz.model.js
+++ b/src/modules/quiz/model/quiz.model.js
@@ -1,0 +1,138 @@
+import mongoose, { Schema } from 'mongoose';
+
+// Schema for each option in a multiple-choice question
+const optionSchema = new Schema({
+  id: { 
+    type: String, 
+    required: true 
+  },
+  text: { 
+    type: String, 
+    required: true 
+  },
+  isCorrect: { 
+    type: Boolean, 
+    required: true,
+    select: false // Ensure this is not returned to the client by default
+  }
+});
+
+// Schema for a quiz question
+const questionSchema = new Schema({
+  questionId: {
+    type: String,
+    required: true
+  },
+  text: {
+    type: String,
+    required: true
+  },
+  options: [optionSchema],
+  explanation: {
+    type: String,
+    select: false // Explanation is not returned to the client by default
+  }
+});
+
+// Main quiz schema
+const quizSchema = new mongoose.Schema(
+  {
+    courseId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    // Link to a specific section (quizzes are associated at section level in course model)
+    sectionId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    // This is the ID that will be referenced in the course model's section.quizId
+    quizId: {
+      type: String,
+      required: true,
+      trim: true,
+      unique: true,
+    },
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    description: {
+      type: String,
+      trim: true,
+    },
+    timeLimit: {
+      type: Number, // Time limit in minutes
+      default: 30
+    },
+    passingScore: {
+      type: Number, // Percentage required to pass
+      default: 70
+    },
+    questions: [questionSchema],
+    isActive: {
+      type: Boolean,
+      default: true
+    },
+    createdBy: {
+      type: String,
+      required: true
+    }
+  },
+  { timestamps: true }
+);
+
+// Method to get quiz without answers for user consumption
+quizSchema.methods.omitAnswers = function () {
+  const quizObject = this.toObject();
+  
+  // Remove isCorrect from all options in all questions
+  if (quizObject.questions && Array.isArray(quizObject.questions) && quizObject.questions.length > 0) {
+    quizObject.questions.forEach(question => {
+      if (question.options && Array.isArray(question.options) && question.options.length > 0) {
+        question.options.forEach(option => {
+          delete option.isCorrect;
+        });
+      }
+      // Also remove explanation
+      delete question.explanation;
+    });
+  }
+  
+  return quizObject;
+};
+
+// Static method to get a quiz by ID without answers
+quizSchema.statics.findByIdWithoutAnswers = async function (id) {
+  const quiz = await this.findById(id);
+  if (!quiz) return null;
+  return quiz.omitAnswers();
+};
+
+// Helper function to process lean documents that don't have methods
+quizSchema.statics.omitAnswersFromLeanDocument = function(quizObj) {
+  if (!quizObj) return null;
+  
+  const processedQuiz = { ...quizObj };
+  
+  // Remove isCorrect from all options in all questions
+  if (processedQuiz.questions && Array.isArray(processedQuiz.questions) && processedQuiz.questions.length > 0) {
+    processedQuiz.questions.forEach(question => {
+      if (question.options && Array.isArray(question.options) && question.options.length > 0) {
+        question.options.forEach(option => {
+          delete option.isCorrect;
+        });
+      }
+      // Also remove explanation
+      delete question.explanation;
+    });
+  }
+  
+  return processedQuiz;
+};
+
+const QuizModel = mongoose.model('Quiz', quizSchema);
+export default QuizModel;

--- a/src/modules/quiz/routes/index.js
+++ b/src/modules/quiz/routes/index.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import quizRoutes from './quiz.routes.js';
+
+const router = Router();
+
+router.use('/', quizRoutes);
+
+export default router;

--- a/src/modules/quiz/routes/quiz.routes.js
+++ b/src/modules/quiz/routes/quiz.routes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { getQuizzesByCourse, getQuizzesBySection, getQuizById, createQuiz, updateQuiz, deleteQuiz } from '../controllers/quiz.controller.js';
+import passport from 'passport';
+
+const router = Router();
+
+// Public routes
+router.get('/course/:courseId', getQuizzesByCourse);
+router.get('/section/:sectionId', getQuizzesBySection);
+router.get('/:quizId', getQuizById);
+
+// Protected routes requiring authentication
+router.use(passport.authenticate('jwt', { session: false }));
+router.post('/', createQuiz);
+router.put('/:quizId', updateQuiz);
+router.delete('/:quizId', deleteQuiz);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,8 +1,9 @@
-﻿import { Router } from 'express';
+import { Router } from 'express';
 import authRoutes from '../modules/auth/auth.route.js';
 import courseRoutes from '../modules/course/routes/index.js';
 import progressRoutes from '../modules/course-progress/course.progress.route.js';
 import enrollmentRoutes from '../modules/enrolment/enrol.route.js';
+import quizRoutes from '../modules/quiz/routes/index.js';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use('/auth', authRoutes);
 router.use('/courses', courseRoutes);
 router.use('/progress', progressRoutes);
 router.use('/enrollment', enrollmentRoutes);
+router.use('/quizzes', quizRoutes);
 
 export default router;


### PR DESCRIPTION
# What has been done? 
## Course Model
The `chapterSchema` now uses `ChapterTypeEnum` to ensure consistent chapter types across the application, without unnecessary properties.
## Quiz Model
The `quizSchema` now correctly aligns with the course schema by making `quizId` unique. This ensures a section can only have one quiz.
## Quiz Controller
•  **`createQuiz`**: Now associates a quiz with a section, not a chapter.
•  **`getQuizzesByChapter`** has been renamed to **`getQuizzesBySection`** to reflect the new data model accurately.
•  **`deleteQuiz`**: Properly removes the quiz reference from the section when a quiz is deleted.
•  **`updateQuiz`**: Has been fixed to avoid referencing a non-existent quiz array in the course model.
## Quiz Routes
The routes have been updated to match the changes in the controller, with `/chapter/:chapterId` replaced by `/section/:sectionId`.